### PR TITLE
Use mirrored installer URLs

### DIFF
--- a/src/templates/main_page.j2
+++ b/src/templates/main_page.j2
@@ -225,7 +225,7 @@
 
             <div id="linux" class="tab-content active">
                 <div class="code-block">
-                    <pre><code id="linux-code" class="language-bash">curl -LsSf https://astral.sh/uv/install.sh | INSTALLER_DOWNLOAD_URL=https://wheelnext.astral.sh/v0.0.3 sh
+                    <pre><code id="linux-code" class="language-bash">curl -LsSf https://wheelnext.astral.sh/v0.0.3/uv-installer.sh | INSTALLER_DOWNLOAD_URL=https://wheelnext.astral.sh/v0.0.3 sh
 uv venv
 uv pip install --index https://wheelnext.github.io/variants-index-test/v0.0.3/ &lt;package_name&gt;</code></pre>
                     <button class="copy-btn" onclick="copyCode('linux-code')">Copy</button>
@@ -234,7 +234,7 @@ uv pip install --index https://wheelnext.github.io/variants-index-test/v0.0.3/ &
 
             <div id="windows" class="tab-content">
                 <div class="code-block">
-                    <pre><code id="windows-code" class="language-powershell">powershell -c { $env:INSTALLER_DOWNLOAD_URL = 'https://wheelnext.astral.sh/v0.0.3'; irm https://astral.sh/uv/install.ps1 | iex }
+                    <pre><code id="windows-code" class="language-powershell">powershell -c { $env:INSTALLER_DOWNLOAD_URL = 'https://wheelnext.astral.sh/v0.0.3'; irm https://wheelnext.astral.sh/v0.0.3/uv-installer.ps1 | iex }
 uv venv
 uv pip install torch</code></pre>
                     <button class="copy-btn" onclick="copyCode('windows-code')">Copy</button>


### PR DESCRIPTION
The main installer URL has switched to hash pinning with the hashes of regular uv, which fails validation for the wheelnext uv. Switching to the mirrored installer (from the 0.9.14 release that the branch is based on) solves this.

For the next uv wheel variant preview, we'll provide an updated installer with the new hashes.